### PR TITLE
[fix] 406: Fix unmatched activities with first-timers

### DIFF
--- a/resort/book/js/booking-lesson-app/lesson/activity-lessons.component.js
+++ b/resort/book/js/booking-lesson-app/lesson/activity-lessons.component.js
@@ -77,23 +77,17 @@
     }
 
     function createLessons(type) {
-      return Lesson.newFromDates(type, vm.dates, 4, 'Ski');
+      return Lesson.newFromDates(type, vm.dates, 4, null);
     }
 
     function createAllLessons() {
       // LN Look for a better way to do this
       vm.results.private.lessons = createLessons('private.lessons');
 
-      // Add FTs to group lessons
       const types = ['adults', 'children', 'mini'];
 
       for (const type of types) {
-        let lessons = createLessons(`group.${type}`);
-        let firstLesson = lessons[0];
-        const fts = _.filter(vm.participants[type], p => isParticipantFT(firstLesson, p));
-
-        firstLesson.participants = fts;
-        vm.results.group[type] = lessons;
+        vm.results.group[type] = createLessons(`group.${type}`);
       }
     }
 

--- a/resort/book/js/booking-lesson-app/lesson/lesson-item.component.js
+++ b/resort/book/js/booking-lesson-app/lesson/lesson-item.component.js
@@ -40,12 +40,13 @@ function LessonItemComponent() {
 
   LessonItemController.$inject = [
     '_',
+    'filterActivities',
     'isParticipantFT',
     'settings',
   ];
 }
 
-function LessonItemController(_, isParticipantFT, settings) {
+function LessonItemController(_, filterActivities, isParticipantFT, settings) {
   const CHILD_ADVICE = 'It is strongly advised for any child aged 5 and under to do ' +
     'a separate lesson, either as a group or a private lesson';
   const MAX_PEOPLE_ADVICE = 'Up to 4 people can join a lesson';
@@ -205,12 +206,13 @@ function LessonItemController(_, isParticipantFT, settings) {
     }
   }
 
-  function buildActivitiesList() {
+  function buildActivitiesList(participants) {
     const baseActivities = isLessonMatchTypes(['private'])
       ? settings.ACTIVITY_TYPES.private
       : settings.ACTIVITY_TYPES.default;
+    const activities = _.intersection(vm.activities, baseActivities);
 
-    return _.intersection(vm.activities, baseActivities);
+    return filterActivities(activities, participants);
   }
 
   function invalidActivityAdvice(participantName) {

--- a/resort/book/js/booking-lesson-app/lesson/lessons.controller.js
+++ b/resort/book/js/booking-lesson-app/lesson/lessons.controller.js
@@ -36,13 +36,13 @@
         private: {
           instructor: {
             required: false,
-            details: null
+            details: null,
           },
           requests: null,
-          lessons: []
+          lessons: [],
         },
         disability: [],
-      }
+      },
     };
 
     // Binds functions
@@ -72,7 +72,7 @@
         children: [],
         mini: [],
         normal: [],
-        disabled: []
+        disabled: [],
       };
 
       for (const participant of participants) {
@@ -159,9 +159,9 @@
         return $window.parent.postMessage(
           {
             msg: 'LESSONS_DATA',
-            results: vm.getResults()
+            results: vm.getResults(),
           },
-          '*'
+          '*',
         );
       }
 

--- a/resort/book/js/booking-lesson-app/services/activities-filter.service.js
+++ b/resort/book/js/booking-lesson-app/services/activities-filter.service.js
@@ -1,0 +1,51 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('BookingLessonApp')
+    .factory('filterActivities', filterActivities);
+
+  filterActivities.$inject = ['_', 'settings'];
+
+  String.prototype.titlelize = function () {
+    let strs = this.toLowerCase().split(' ');
+    for (let i = 0; i < strs.length; i++) {
+      strs[i] = strs[i].charAt(0).toUpperCase() + strs[i].slice(1);
+    }
+    return strs.join(' ');
+  };
+
+  function filterActivities(_, settings) {
+    const BASE_ACTIVITIES = settings.ACTIVITY_TYPES.private;
+
+    return function (activities, participants) {
+      return _.intersection(
+        activities,
+        BASE_ACTIVITIES,
+        getParticipantsActivities(participants)
+      );
+    };
+
+    function getParticipantsActivities(participants) {
+      let activities = [];
+
+      for (const participant of participants) {
+        let participantActivities = JSON.parse(participant.activities);
+        participantActivities = _.reduce(
+          participantActivities,
+          (acc, value, key) => {
+            if (value) {
+              let act = key.replace('Chosen', '');
+              acc.push(act.titlelize());
+            }
+            return acc;
+          },
+          [],
+        );
+        activities = [...activities, ...participantActivities];
+      }
+
+      return _.uniq(activities);
+    }
+  }
+})();

--- a/resort/book/js/lessons.test.main.js
+++ b/resort/book/js/lessons.test.main.js
@@ -98,7 +98,7 @@
             {
               'skiChosen': true,
               'snowboardChosen': true,
-              'telemarkChosen': true,
+              'telemarkChosen': false,
               'snowbikeChosen': false,
               'snowmobileChosen': false,
               'snowshoeChosen': false,
@@ -121,7 +121,7 @@
             {
               'skiChosen': true,
               'snowboardChosen': true,
-              'telemarkChosen': true,
+              'telemarkChosen': false,
               'snowbikeChosen': false,
               'snowmobileChosen': false,
               'snowshoeChosen': false,

--- a/resort/book/js/lessons.test.main.js
+++ b/resort/book/js/lessons.test.main.js
@@ -96,9 +96,9 @@
           age: 40,
           activities: JSON.stringify(
             {
-              'skiChosen': true,
+              'skiChosen': false,
               'snowboardChosen': true,
-              'telemarkChosen': false,
+              'telemarkChosen': true,
               'snowbikeChosen': false,
               'snowmobileChosen': false,
               'snowshoeChosen': false,
@@ -119,9 +119,9 @@
           age: 36,
           activities: JSON.stringify(
             {
-              'skiChosen': true,
+              'skiChosen': false,
               'snowboardChosen': true,
-              'telemarkChosen': false,
+              'telemarkChosen': true,
               'snowbikeChosen': false,
               'snowmobileChosen': false,
               'snowshoeChosen': false,
@@ -173,7 +173,7 @@
               'snowshoeChosen': false,
             },
           ),
-          skiLevel: 5,
+          skiLevel: 1,
           snowboardLevel: 2,
           telemarkLevel: 1,
           snowbikeLevel: 1,

--- a/resort/book/lessons.html
+++ b/resort/book/lessons.html
@@ -47,6 +47,7 @@
 <script src="js/booking-lesson-app/components/no-lesson.component.js"></script>
 <script src="js/booking-lesson-app/components/results-panel.component.js"></script>
 <script src="js/booking-lesson-app/factories/wix.factory.js"></script>
+<script src="js/booking-lesson-app/services/activities-filter.service.js"></script>
 <script src="js/booking-lesson-app/services/ft-checker.service.js"></script>
 <script src="js/booking-lesson-app/lesson/lessons.controller.js"></script>
 <script src="js/booking-lesson-app/lesson/lesson.factory.js"></script>


### PR DESCRIPTION
## What

Trello Card: https://trello.com/c/j5Kfr1Zp

- Added a fix to check if the sent activities actually matched with the members' selected activities.
- Improve the disabling checkbox logics (since it was heavily affected by the problem above).

## Why

I did this change in order to fix the two errors found by Davin:

- [Susan Park][1]
- [Jenn is doing Snowboarding Activity and is a FTP.][2]

## Major Changes

N/A

## Requirements for Merging
N/A

## Testing Plan

- [x] Test on local machine
- [ ] Test on [Demo site][3]
- [ ] Test on Wix site

## Feedback

CC: @haoged 

[1]: https://www.useloom.com/share/a066780c4cb645058dcadb73d8672e86
[2]: https://www.useloom.com/share/dc34bcb6941f4c0797700f2747b26138
[3]: http://tklarryonline.me/wix-html-components/resort/book/lessons.test